### PR TITLE
Fix review JSON parsing to handle nested braces in reasoning

### DIFF
--- a/.github/prompts/review.md
+++ b/.github/prompts/review.md
@@ -37,5 +37,3 @@ After reviewing all implementations, select the best one.
 Your response will be validated against a JSON schema. Provide:
 - "best": The implementation number (1, 2, or 3)
 - "reasoning": A detailed comparison explaining why this implementation is best
-- "quality_score": Code quality score from 0-100 (optional)
-- "completeness_score": How complete the implementation is from 0-100 (optional)

--- a/.github/workflows/implement-issue.yml
+++ b/.github/workflows/implement-issue.yml
@@ -297,7 +297,7 @@ jobs:
           echo "Starting review..."
 
           # Define JSON schema for structured output
-          JSON_SCHEMA='{"type":"object","properties":{"best":{"type":"integer","minimum":1,"maximum":3},"reasoning":{"type":"string"},"quality_score":{"type":"integer","minimum":0,"maximum":100},"completeness_score":{"type":"integer","minimum":0,"maximum":100}},"required":["best","reasoning"]}'
+          JSON_SCHEMA='{"type":"object","properties":{"best":{"type":"integer","minimum":1,"maximum":3},"reasoning":{"type":"string"}},"required":["best","reasoning"]}'
 
           claude --print "$(cat /tmp/review-prompt.md)" \
             --output-format json \
@@ -317,7 +317,7 @@ jobs:
 
           # Create mock review result matching --json-schema output format
           # The result field contains a JSON string that parses to the decision object
-          echo "{\"result\": \"{\\\"best\\\": $WINNER, \\\"reasoning\\\": \\\"Dry run mock selection\\\", \\\"quality_score\\\": 85, \\\"completeness_score\\\": 90}\"}" > review-result.json
+          echo "{\"result\": \"{\\\"best\\\": $WINNER, \\\"reasoning\\\": \\\"Dry run mock selection\\\"}\"}" > review-result.json
           cat review-result.json
 
       - name: Parse review and create PR
@@ -396,11 +396,8 @@ sys.exit(1)
           fi
 
           REASONING=$(echo "$DECISION_JSON" | jq -r '.reasoning // "No reasoning provided"')
-          QUALITY=$(echo "$DECISION_JSON" | jq -r '.quality_score // "N/A"')
-          COMPLETENESS=$(echo "$DECISION_JSON" | jq -r '.completeness_score // "N/A"')
 
           echo "Selected implementation: $BEST"
-          echo "Quality: $QUALITY, Completeness: $COMPLETENESS"
 
           WINNING_BRANCH="impl-${{ github.run_id }}-$BEST"
           echo "winning_branch=$WINNING_BRANCH" >> $GITHUB_OUTPUT
@@ -410,10 +407,6 @@ sys.exit(1)
 
           **Issue:** #${{ steps.issue.outputs.number }}
           **Selected:** Implementation $BEST
-
-          ### Scores
-          - Quality: $QUALITY/100
-          - Completeness: $COMPLETENESS/100
 
           ### Reasoning
           $REASONING


### PR DESCRIPTION
The previous regex pattern `\{[^{}]*"best"[^{}]*\}` failed when Claude's
reasoning contained curly braces (common in code explanations). This caused
"Could not find decision JSON in review output" errors.

New parsing strategy:
1. Try parsing entire response as JSON directly
2. Extract JSON from markdown code blocks
3. Use Python parser that properly tracks brace depth and string escaping

This handles all common Claude response formats including JSON with nested
braces, markdown code blocks, and text before/after the JSON.