### PR TITLE
Fix node module resolution for claude-agent-runner.js

### DIFF
--- a/templates/workflows/claude-implement.yml
+++ b/templates/workflows/claude-implement.yml
@@ -227,7 +227,7 @@ jobs:
 
           # Run agent runner and capture exit code
           set +e
-          echo "$IMPL_PROMPT" | node .github/claude-parallel/scripts/claude-agent-runner.js \
+          echo "$IMPL_PROMPT" | node node_modules/swellai/templates/scripts/claude-agent-runner.js \
             --cwd "$(pwd)" \
             --model ${{ inputs.claude_model || 'claude-opus-4-5-20251101' }} \
             --mode implementation \
@@ -399,7 +399,7 @@ jobs:
           echo "Linear issue: ${{ needs.generate-matrix.outputs.linear_issue }}"
 
           # Run agent runner in review mode (schema automatically applied)
-          echo "$REVIEW_PROMPT" | node .github/claude-parallel/scripts/claude-agent-runner.js \
+          echo "$REVIEW_PROMPT" | node node_modules/swellai/templates/scripts/claude-agent-runner.js \
             --cwd "$(pwd)" \
             --model ${{ inputs.claude_model || 'claude-opus-4-5-20251101' }} \
             --mode review \
@@ -828,7 +828,7 @@ jobs:
           echo "Linear issue: ${{ needs.generate-matrix.outputs.linear_issue }}"
 
           # Run agent runner in implementation mode
-          echo "$VERIFY_PROMPT" | node .github/claude-parallel/scripts/claude-agent-runner.js \
+          echo "$VERIFY_PROMPT" | node node_modules/swellai/templates/scripts/claude-agent-runner.js \
             --cwd "$(pwd)" \
             --model ${{ inputs.claude_model || 'claude-opus-4-5-20251101' }} \
             --mode implementation \


### PR DESCRIPTION
Feature Request: Node Module Resolution in other repos - Update claude-agent-runner.js invocation paths from local installed path to npm package path for proper module resolution.

Summary of changes:
- Updated 3 invocations of claude-agent-runner.js in templates/workflows/claude-implement.yml
- Changed path from .github/claude-parallel/scripts/claude-agent-runner.js to node_modules/swellai/templates/scripts/claude-agent-runner.js
- Line 230 (implementation step): Updated path
- Line 402 (review step): Updated path  
- Line 831 (verify step): Updated path

Detailed review of changes:

The core change updates how the claude-agent-runner.js script is invoked within the template workflow file that gets installed to user repositories.

**Why this matters:**
When users install the swellai package via npm, the scripts are available at node_modules/swellai/templates/scripts/. The previous path (.github/claude-parallel/scripts/) pointed to a bundled copy that lacks proper access to npm dependencies like @libsql, causing module resolution failures at runtime.

**Path correction note:**
The original feature request specified node_modules/swellai/dist/scripts/ as the target path. However, analysis of the package.json "files" array (which publishes "dist/" and "templates/") and the actual script locations (templates/scripts/) revealed the correct path is node_modules/swellai/templates/scripts/. This implementation uses the correct path based on the actual package structure.

**Changes to review:**
1. templates/workflows/claude-implement.yml - Look at lines 230, 402, and 831 where the script invocation paths were updated. The rest of the workflow file remains unchanged.

**Scope:**
- Only claude-implement.yml template was modified (as specified in feature request)
- claude-plan.yml uses different scripts (planning-agent.js, linear-agent.js) and was not in scope
- Local development scripts (parallel-impl.sh, reusable workflows) still use TypeScript source and were not modified